### PR TITLE
ASR9K reload and login

### DIFF
--- a/condoor/controllers/protocols/telnet.py
+++ b/condoor/controllers/protocols/telnet.py
@@ -69,12 +69,13 @@ class Telnet(Protocol):
             username_prompt = USERNAME_PROMPT
         #              0            1               2                3              4            5      6
         events = [ESCAPE_CHAR, PRESS_RETURN, STANDBY_CONSOLE, username_prompt, password_prompt, more, prompt,
-                  #     7                8                 9               10
-                  rommon_prompt, UNABLE_TO_CONNECT, RESET_BY_PEER, pexpect.TIMEOUT]
+                  #     7                8                 9               10         11
+                  rommon_prompt, UNABLE_TO_CONNECT, RESET_BY_PEER, pexpect.TIMEOUT, PASSWORD_OK]
 
         transitions = [
             (ESCAPE_CHAR, [0], 1, None, 20),
             (PRESS_RETURN, [0, 1], 1, self.send_new_line, 10),
+            (PASSWORD_OK, [0, 1], 1, self.send_new_line, 10),
             (STANDBY_CONSOLE, [0, 5], -1, ConnectionError("Standby console", self.hostname), 0),
             (username_prompt, [0, 1, 5, 6], -1, self.save_pattern, 0),
             (password_prompt, [0, 1, 5], -1, self.save_pattern, 0),
@@ -111,7 +112,8 @@ class Telnet(Protocol):
                   pexpect.TIMEOUT, pexpect.EOF]
 
         transitions = [
-            (username_prompt, [0, 1], 1, self.send_username, 10),
+            (username_prompt, [0], 1, self.send_username, 10),
+            (username_prompt, [1], 1, None, 10),
             (password_prompt, [0, 1], 2, self.send_pass, 20),
             (username_prompt, [2], -1, self.authentication_error, 0),
             (prompt, [0, 1, 2], -1, None, 0),

--- a/condoor/platforms/generic.py
+++ b/condoor/platforms/generic.py
@@ -30,7 +30,6 @@
 
 import re
 import pexpect
-
 from threading import Lock
 
 from ..exceptions import \
@@ -357,7 +356,6 @@ class Connection(object):
         self.ctrl.sendline()
         self.ctrl.setecho(True)
 
-
     def _execute_command(self, cmd, timeout, wait_for_string):
         with self.command_execution_pending:
             try:
@@ -447,6 +445,16 @@ class Connection(object):
     @action
     def _send_lf(self, ctx):
         ctx.ctrl.send('\r')
+        return True
+
+    @action
+    def _send_line(self, ctx):
+        ctx.ctrl.send('\r\n')
+        return True
+
+    @action
+    def _send_yes(self, ctx):
+        ctx.ctrl.sendline('yes')
         return True
 
     @action


### PR DESCRIPTION
Mainly two changes:
1. For migration purpose, the reload for ASR9K classic XR and ASR9K eXR. Re-configuring authentication is implemented in CSM plugins.
2. For eXR login, return when seeing "Password OK" and only enter username once.

Tested reloads(and logins) in both ASR9K classic XR and eXR. Also the migration.