### PR TITLE
Added disconnect for reconnect timeout after reloading - console connection

### DIFF
--- a/condoor/controllers/pexpect_ctrl.py
+++ b/condoor/controllers/pexpect_ctrl.py
@@ -35,7 +35,7 @@ from ..utils import to_list
 from ..utils import delegate
 
 from ..controllers.protocols import make_protocol
-from ..exceptions import ConnectionError
+from ..exceptions import ConnectionError, ConnectionTimeoutError
 
 import pexpect
 
@@ -133,6 +133,10 @@ class Controller(object):
                                         connected = False
                         else:
                             connected = False
+                    except ConnectionTimeoutError as e:
+                        self._dbg(40, "Error during connecting to device: {}".format(e.message))
+                        self.disconnect()
+                        raise
                     except Exception as e:
                         self._dbg(40, "Error during connecting to device: {}".format(e.message))
                         raise


### PR DESCRIPTION
Sometimes the device reloads after install activating some package. In the case of console connection, if we try to reconnect to the device during the reload and the device is still not ready for authentication yet, the connection times out, in this case, we need to make sure to send "]q" so that we release the connection, otherwise future connection attempts will be refused.

I'm not sure if this disconnect method is the best thing to call because it does send "exit" 10 times in a row, which we don't need to if the device is going through reload. So far, the testing I've done seems to indicate that it is fine. Please let me know if you have concerns or better alternatives for this.