### PR TITLE
Enable CommandError exception for show version brief

### DIFF
--- a/condoor/platforms/IOS.py
+++ b/condoor/platforms/IOS.py
@@ -48,7 +48,8 @@ class Connection(generic.Connection):
     command_syntax_re = re.compile('\% Bad IP address or host name% Unknown command or computer name, '
                                    'or unable to find computer address|'
                                    '\% Ambiguous command:.*"|'
-                                   '\% Type "show \?" for a list of subcommands')
+                                   '\% Type "show \?" for a list of subcommands|'
+                                   "% Invalid input detected at '\^' marker\.")
 
     platform_prompt = generic.prompt_patterns['IOS']
 


### PR DESCRIPTION
This is the one line enhancement that will enable CommandError exception in condoor/__init__.py:
_update_device_info, where  "show version brief" is tried first. If the syntax is not supported, a 
CommandError exception is raised then "show version" is sent. 

In IOS-XE, the error message from "show version brief" is "% Invalid input detected at '^' marker ."
Adding this new pattern will enable CommandError exception so "show version" is sent for IOS-XE.

Otherwise, "show version" will not be sent for IOS-XE and csmserver/parser/loader.py will set ASR900 as the "generic" software_platform and raise "UnknownSoftwarePlatform" exception. 