### PR TITLE
Change to max_transitions

### DIFF
--- a/condoor/controllers/fsm.py
+++ b/condoor/controllers/fsm.py
@@ -84,8 +84,6 @@ class FSM(object):
 
         """
 
-    max_transitions = 20
-
     class Context(object):
         _slots__ = ['fsm_name', 'ctrl', 'event_index', 'event', 'state', 'finished', 'msg']
         fsm_name = "FSM"
@@ -111,7 +109,7 @@ class FSM(object):
             return "FSM Context:E={},S={},FI={},M='{}'".format(
                 self.event, self.state, self.finished, self.msg)
 
-    def __init__(self, name, ctrl, events, transitions, init_pattern=None, timeout=300):
+    def __init__(self, name, ctrl, events, transitions, init_pattern=None, timeout=300, max_transitions=20):
         """This is a FSM class constructor.
 
         Args:
@@ -121,6 +119,7 @@ class FSM(object):
             transitions (list): List of tuples in defining the state machine transitions.
             init_pattern (str): The pattern that was expected in the previous operation.
             timeout (int): Timeout between states in seconds. Defaults to 300 seconds.
+            max_transitions (int): Max number of transitions allowed before quiting the FSM.
 
         The transition tuple format is as follows::
 
@@ -138,6 +137,7 @@ class FSM(object):
         self.timeout = timeout
         self.name = name
         self.init_pattern = init_pattern
+        self.max_transitions = max_transitions
         self.logger = logging.getLogger('condoor.fsm')
 
         self.transition_table = self._compile(transitions, events)

--- a/condoor/platforms/generic.py
+++ b/condoor/platforms/generic.py
@@ -257,7 +257,7 @@ class Connection(object):
 
         self._info("Ignoring. Not implemented for this platform")
 
-    def run_fsm(self, name, command, events, transitions, timeout):
+    def run_fsm(self, name, command, events, transitions, timeout, max_transitions=20):
         """This method instantiate and run the Finite State Machine for the current device connection. Here is the
         example of usage::
 
@@ -290,6 +290,7 @@ class Connection(object):
             events (list): List of expected strings or pexpect.TIMEOUT exception expected from the device.
             transitions (list): List of tuples in defining the state machine transitions.
             timeout (int): Default timeout between states in seconds.
+            max_transitions (int): Default maximum number of transitions allowed for FSM.
 
         The transition tuple format is as follows::
 
@@ -330,7 +331,7 @@ class Connection(object):
         """
 
         self._send_command(command)
-        fsm = FSM(name, self.ctrl, events, transitions, timeout=timeout)
+        fsm = FSM(name, self.ctrl, events, transitions, timeout=timeout, max_transitions=max_transitions)
         return fsm.run()
 
     @property


### PR DESCRIPTION
The change in the diff is to allow users who create FSM to set max_transitions. This was a problem during migration, when we have to use "copy" CLI to copy a greater than 1.3 GB tar file to harddisk:, the CLI would sometimes give connection timeout and error out after 10 minutes of copying. I had to send a newline every once in a while - every 50 of "C" is read ("CCCCC" is the progress bar). When I do that, the default max_transitions 20 is reached before the "copy" command completes. Therefore, I made this change.