### PR TITLE
ASR907 console can be disconnected during reload and exec timeout

### DIFF
--- a/condoor/drivers/IOS.py
+++ b/condoor/drivers/IOS.py
@@ -6,7 +6,7 @@ import logging
 import pexpect
 
 from condoor.drivers.generic import Driver as Generic
-from condoor.actions import a_send_password, a_expected_prompt, a_send_line, a_send, a_disconnect
+from condoor.actions import a_send_password, a_expected_prompt, a_send_line, a_send, a_disconnect, a_reconnect
 from condoor.exceptions import ConnectionAuthenticationError, ConnectionError
 from condoor.fsm import FSM
 
@@ -78,10 +78,10 @@ class Driver(Generic):
 
         transitions = [
             (SAVE_CONFIG, [0], 1, partial(a_send_line, response), 60),
-            (PROCEED, [0, 1], 2, partial(a_send, "\r"), 10),
+            (PROCEED, [0, 1], 2, partial(a_send, "\r"), reload_timeout),
             # if timeout try to send the reload command again
             (pexpect.TIMEOUT, [0], 0, partial(a_send_line, self.reload_cmd), 10),
-            (pexpect.TIMEOUT, [2], -1, a_disconnect, 0),
+            (pexpect.TIMEOUT, [2], -1, a_reconnect, 0),
             (pexpect.EOF, [0, 1, 2], -1, a_disconnect, 0)
         ]
         fsm = FSM("IOS-RELOAD", self.device, events, transitions, timeout=10, max_transitions=5)


### PR DESCRIPTION
Minor changes for:

1.       XE driver: 
   a.       Remove max_transitions=5 and use the default value of 20.
   b.       Add a new event handler in the reload FSM that the moment seeing the booting message “System Bootstrap”, Condoor disconnects the connection.
   c.       Add EOF handler for state 3 to avoid FSM looping in case host disconnect occurs in state 3.

2.       IOS driver:
   a.       Use reload_timeout for the PROCEED event
   b.       Use a_reconnect for the pexpect.TIMEOUT event at state 2.

 