### PR TITLE
allow periods in IOS/IOS-XE prompts

### DIFF
--- a/condoor/patterns.yaml
+++ b/condoor/patterns.yaml
@@ -138,7 +138,7 @@ eXR:
     description: 'Command syntax error'
 
 IOS:
-  prompt: '(?P<hostname>[\w\-\_\=\+]+)(\([^()]*\))?[#|>]'
+  prompt: '(?P<hostname>[\w\-\_\=\+\.]+)(\([^()]*\))?[#|>]'
   # prompt_dynamic: '{prompt}(\([^()]*\))?[#>]'
   prompt_dynamic: '{hostname}(\([^()]*\))?[#>]'
   prompt_default: 'Router[#>]'
@@ -155,7 +155,7 @@ IOS:
     description: 'Command syntax error'
 
 XE:
-  prompt: '(?P<hostname>[\w\-\_\=\+]+)(\([^()]*\))?[#|>]'
+  prompt: '(?P<hostname>[\w\-\_\=\+\.]+)(\([^()]*\))?[#|>]'
   # prompt_dynamic: '{prompt}(\([^()]*\))?[#>]'
   prompt_dynamic: '{hostname}(\([^()]*\))?[#>]'
   prompt_default: 'Router[#>]'


### PR DESCRIPTION
Currently condoor breaks (detects hostname as the section trailing the period) if a period is present in a hostname, seems like it shouldn't?